### PR TITLE
Fix errors and warnings for 32-bit x86 architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,36 @@ branches:
     - master
 
 language: rust
+os: linux
+dist: focal
 
 jobs:
   include:
     # amd64 linux
     - rust: stable
-      os: linux
       arch: amd64
+      before_install: 
+      - sudo apt update
+      - sudo apt install -y gcc-multilib # Allow compilation for 32-bit target
     - rust: beta
-      os: linux
       arch: amd64
+      before_install: 
+      - sudo apt update
+      - sudo apt install -y gcc-multilib
     - rust: nightly
       env: FEATURES=--features=nightly
-      os: linux
       arch: amd64
+      before_install: 
+      - sudo apt update
+      - sudo apt install -y gcc-multilib
 
     # arm64 linux
     - rust: stable
-      os: linux
       arch: arm64
     - rust: beta
-      os: linux
       arch: arm64
     - rust: nightly
       env: FEATURES=--features=nightly
-      os: linux
       arch: arm64
 
 install: ci/install.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b64-ct"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -24,7 +24,7 @@ readme = "README.md"
 [features]
 default = ["std"]
 std = []
-nightly = [] # Used only for testing
+nightly = []      # Used only for testing
 
 [dev-dependencies]
 rand = "0.7"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,6 +6,8 @@ set -xeo pipefail
 # need to be repeated on other os and arch.
 if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" = "amd64" ]
 then
+    rustup target add i686-unknown-linux-gnu
+
     rustup target add wasm32-wasi
     cargo install cargo-wasi
     curl -L https://github.com/CraneStation/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz \
@@ -16,4 +18,5 @@ then
 
     rustup target add x86_64-apple-darwin
     rustup target add aarch64-apple-darwin
+
 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,6 +9,9 @@ cargo test $FEATURES
 # need to be repeated on other os and arch.
 if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" = "amd64" ]
 then
+    cargo test --no-default-features --target=i686-unknown-linux-gnu
+    cargo test $FEATURES --target=i686-unknown-linux-gnu
+
     cargo wasi test --no-default-features
     cargo wasi test $FEATURES
 

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -4,6 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
 #[rustfmt::skip]

--- a/src/decode/avx2.rs
+++ b/src/decode/avx2.rs
@@ -4,6 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
 use crate::avx2::*;

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -190,7 +190,7 @@ mod tests {
     use super::*;
 
     use crate::test_support::rand_base64_size;
-    use crate::{ToBase64};
+    use crate::ToBase64;
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub(super) fn test_avx2() -> avx2::Avx2 {
@@ -367,7 +367,7 @@ mod tests {
 
         let mut v: Vec<u8> = vec![];
         let bytes_per_line = BASE64_PEM_WRAP * 3 / 4;
-        for _i in 0..2*bytes_per_line {
+        for _i in 0..(2 * bytes_per_line) {
             let encoded = v.to_base64(BASE64_PEM);
             let decoded = decode64(encoded.as_bytes(), decoder, packer).unwrap();
             assert_eq!(v, decoded);

--- a/src/encode/avx2.rs
+++ b/src/encode/avx2.rs
@@ -4,6 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
 use crate::avx2::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! [not sufficient on some platforms]: https://ts.data61.csiro.au/projects/TS/cachebleed/
 
 #![no_std]
-#![cfg_attr(all(test, feature = "nightly"), feature(test, bench_black_box))]
+#![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
 extern crate alloc;
 #[cfg(any(test, feature = "std"))]


### PR DESCRIPTION
Fixes #10 (Disable compilation of avx2 code on i686 architectures)
Also fixes `impl_lcm_array` macro to avoid warnings
Bumps patch version so we can re-release