### PR TITLE
update wasi rust target to wasip1

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,7 +8,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_CPU_ARCH" = "amd64" ]
 then
     rustup target add i686-unknown-linux-gnu
 
-    rustup target add wasm32-wasi
+    rustup target add wasm32-wasip1
     cargo install cargo-wasi
     curl -L https://github.com/CraneStation/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz \
         | sudo tar xJf - --strip-components=1 -C /usr/local/bin wasmtime-dev-x86_64-linux/wasmtime
@@ -18,5 +18,4 @@ then
 
     rustup target add x86_64-apple-darwin
     rustup target add aarch64-apple-darwin
-
 fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,7 +9,6 @@ then
     rustup target add i686-unknown-linux-gnu
 
     rustup target add wasm32-wasip1
-    cargo install cargo-wasi
     curl -L https://github.com/CraneStation/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz \
         | sudo tar xJf - --strip-components=1 -C /usr/local/bin wasmtime-dev-x86_64-linux/wasmtime
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,8 +12,8 @@ then
     cargo test --no-default-features --target=i686-unknown-linux-gnu
     cargo test $FEATURES --target=i686-unknown-linux-gnu
 
-    cargo wasi test --no-default-features
-    cargo wasi test $FEATURES
+    CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime cargo test --target=wasm32-wasip1 --no-default-features
+    CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime cargo test --target=wasm32-wasip1 $FEATURES 
 
     cargo check --target aarch64-linux-android
     cargo check --target armv7-linux-androideabi


### PR DESCRIPTION
In rust 1.84, the `wasm32-wasi` target has been removed (see [here](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html)).
From 2024/11/7 on, nightly rust uses 1.84, which broke the latest CI build on master; this PR fixes the build by:
1. Renaming to the new tier-2 `was32-wasip1` target
2. Getting rid of `cargo wasi`, which does not support the `wasm32-wasip1` target. I expect that cases that would fail runs of the raw `cargo test` would've failed `cargo wasi test` before as well. For example, tests could fail if  file-system access is required (see e.g. https://github.com/bytecodealliance/cargo-wasi/issues/128), or if other parts of the WASI API are exercised as part of Rust syscalls.
