### PR TITLE
Refactor `impl_lcm_array` macro to avoid using non-existing cfg option

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -49,10 +49,7 @@ const fn lcm(a: usize, b: usize) -> usize {
         if b == 0 {
             return a;
         }
-        if b < a {
-            return gcd(b, a);
-        }
-        gcd(a, b % a)
+        gcd(b, a % b)
     }
 
     a * b / gcd(a, b)

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -94,7 +94,7 @@ trait SplitFrom<T>: Sized {
 }
 
 impl<const M: usize, const N: usize> SplitFrom<[u8; N]> for [u8; M] {
-    /// Turn an array of size N into an slice of arrays with a total size of A * M.
+    /// Reinterpret an array of size `N` as a slice of length-`M` arrays.
     /// Only works if M is an integer divisor of N.
     fn split_from(from: &mut [u8; N]) -> &mut [Self] {
         // Safety:


### PR DESCRIPTION
To avoid having overlapping trait instances, the `impl_lcm_array` macro makes use of a `skip` identifier that expands to something akin to the following:

```rust
impl<T> SplitArray<[T; 32]> for [T; 32] {
    type Output = [[T; 32]; 32 / 32];
    fn split_mut_internal(&mut self) -> &mut Self::Output {
        unsafe { &mut *(self as *mut _ as *mut _) }
    }
}
```

However, in sufficiently modern versions of `rustc` this results in warnings, because `skip` is not a valid option for `cfg`:

```sh
warning: unexpected `cfg` condition name: `skip`
  --> src/encode/mod.rs:71:25
   |
71 |         $(#[cfg(all(not($nm), $nm))])*
   |                         ^^^
...
82 | impl_lcm_array!(32, skip / 32, 32);
   | ---------------------------------- in this macro invocation
   |
   = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(skip)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(skip)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the macro `impl_lcm_array` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR fixxes the issue ~~and updates the macro to use the more modern and accurate `?` notation in the process~~