### PR TITLE
Specify MSRV in toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/fortanix/b64-ct/"
 keywords = ["base64", "constant-time"]
 categories = ["cryptography", "encoding", "no-std"]
 readme = "README.md"
+rust-version = "1.79.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Useful because now that we use various const-related functionality (inline const blocks; const expressions in asserts), our MSRV has shot up